### PR TITLE
Hot fix to work with the latest version of spherical-geometry

### DIFF
--- a/caom2utils/setup.cfg
+++ b/caom2utils/setup.cfg
@@ -33,7 +33,7 @@ license = AGPLv3
 url = http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2
 edit_on_github = False
 github_project = opencadc/caom2tools
-install_requires = cadcdata>=1.2.1 caom2>=2.3.5 astropy>=2.0 spherical-geometry>=1.1.0
+install_requires = cadcdata>=1.2.1 caom2>=2.3.5 astropy>=2.0 spherical-geometry>=1.2.2
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 1.2
 


### PR DESCRIPTION
The new version (1.2.2) of spherical-geometry supports detection and fix of polygon self-intersection. This new version is not compatible with our current implementation in caom2utils. This fix updates our implementation to be compatible with version 1.2.2 of the spherical-geometry library. Since the fix employs a feature provided by this latest version of the library, only version spherical-geometry version 1.2.2 or later can be used from here on.