### PR TITLE
Fixed TypeError when instantiating Artifact.

### DIFF
--- a/caom2/caom2/caom_util.py
+++ b/caom2/caom2/caom_util.py
@@ -190,21 +190,22 @@ def type_check(value, value_type, variable, override=None):
     vtype = value_type
     if value_type == int_32:
         vtype = int
+    if value_type == newstr and isinstance(value, str):
+        vtype = str
     if not isinstance(value, vtype) and value is not override:
-        if vtype != newstr or not isinstance(value, str):
-            if override is not False:
-                raise TypeError(
-                    "Expected {} or {} for {}, received {}".format(
-                        vtype,
-                        override,
-                        variable,
-                        type(value)))
-            else:
-                raise TypeError(
-                    "Expected {} for {}, received {}".format(
-                        vtype,
-                        variable,
-                        type(value)))
+        if override is not False:
+            raise TypeError(
+                "Expected {} or {} for {}, received {}".format(
+                    vtype,
+                    override,
+                    variable,
+                    type(value)))
+        else:
+            raise TypeError(
+                "Expected {} for {}, received {}".format(
+                    vtype,
+                    variable,
+                    type(value)))
     return True
 
 

--- a/caom2/caom2/caom_util.py
+++ b/caom2/caom2/caom_util.py
@@ -86,7 +86,7 @@ import uuid
 from datetime import datetime
 
 import six
-from builtins import bytes, int
+from builtins import bytes, int, str as newstr
 
 
 __all__ = ['TypedList', 'TypedSet', 'TypedOrderedDict', 'ClassProperty']
@@ -191,17 +191,18 @@ def type_check(value, value_type, variable, override=None):
     if value_type == int_32:
         vtype = int
     if not isinstance(value, vtype) and value is not override:
-        if override is not False:
-            raise TypeError(
-                "Expected {} or {} for {}, received {}".format(vtype,
-                                                               override,
-                                                               variable,
-                                                               type(value)))
-        else:
-            raise TypeError(
-                "Expected {} for {}, received {}".format(vtype,
-                                                         variable,
-                                                         type(value)))
+        if vtype != newstr or not isinstance(value, str):
+            if override is not False:
+                raise TypeError(
+                    "Expected {} or {} for {}, received {}".format(vtype,
+                                                                   override,
+                                                                   variable,
+                                                                   type(value)))
+            else:
+                raise TypeError(
+                    "Expected {} for {}, received {}".format(vtype,
+                                                             variable,
+                                                             type(value)))
     return True
 
 

--- a/caom2/caom2/caom_util.py
+++ b/caom2/caom2/caom_util.py
@@ -194,15 +194,17 @@ def type_check(value, value_type, variable, override=None):
         if vtype != newstr or not isinstance(value, str):
             if override is not False:
                 raise TypeError(
-                    "Expected {} or {} for {}, received {}".format(vtype,
-                                                                   override,
-                                                                   variable,
-                                                                   type(value)))
+                    "Expected {} or {} for {}, received {}".format(
+                        vtype,
+                        override,
+                        variable,
+                        type(value)))
             else:
                 raise TypeError(
-                    "Expected {} for {}, received {}".format(vtype,
-                                                             variable,
-                                                             type(value)))
+                    "Expected {} for {}, received {}".format(
+                        vtype,
+                        variable,
+                        type(value)))
     return True
 
 

--- a/caom2/setup.cfg
+++ b/caom2/setup.cfg
@@ -39,7 +39,7 @@ edit_on_github = False
 github_project = opencadc/caom2tools
 install_requires = future lxml aenum 
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 2.3.5
+version = 2.3.6
 
 
 [entry_points]


### PR DESCRIPTION
When we import str from builtins, str is of type future.types.newstr.newstr. When instantiating an Artifact, a uri str is passed in and the Artifact uri attribute is set to the value of the uri str passed in. The type check can fail if the uri str is of type str since we are expecting a newstr type.

So when importing str from builtins, we do not overwrite str and import it as something else, say newstr. We can now use newstr and str in our type checking code. 