### PR TITLE
Ticket 75582. Currently the samples in a multipolygon are not require…

### DIFF
--- a/caom2utils/caom2utils/polygonvalidator.py
+++ b/caom2utils/caom2utils/polygonvalidator.py
@@ -122,9 +122,10 @@ def validate_polygon(poly):
         # validate self-segment intersection and clockwise direction
         _validate_self_intersection_and_direction(cval1s, cval2s)
 
-    # validate the samples
-    if poly.samples is not None:
-        validate_multipolygon(poly.samples)
+    # Rt 75582 currently samples are not required to
+    # conform to intersection and direction, so do not validate damples
+    # if poly.samples is not None:
+    #     validate_multipolygon(poly.samples)
 
 
 def _validate_is_clockwise(orig_lon, lon):
@@ -147,7 +148,7 @@ def _validate_is_clockwise(orig_lon, lon):
             if np.isclose(rlon[1], orig_lon[1]) or \
                     np.isclose(rlon[1] - 360, orig_lon[1]):
                 raise AssertionError(
-                    'invalid polygon: vertices not in clockwise direction')
+                    'invalid polygon: clockwise winding direction')
             else:
                 raise AssertionError(
                     'software error: compared wrong values')

--- a/caom2utils/caom2utils/tests/data/SampleComposite-CAOM-2.3.xml
+++ b/caom2utils/caom2utils/tests/data/SampleComposite-CAOM-2.3.xml
@@ -126,13 +126,13 @@
                 <caom2:type>2</caom2:type>
               </caom2:vertex>
               <caom2:vertex>
-                <caom2:cval1>1.0</caom2:cval1>
-                <caom2:cval2>4.0</caom2:cval2>
+                <caom2:cval1>3.0</caom2:cval1>
+                <caom2:cval2>3.0</caom2:cval2>
                 <caom2:type>1</caom2:type>
               </caom2:vertex>
               <caom2:vertex>
-                <caom2:cval1>3.0</caom2:cval1>
-                <caom2:cval2>3.0</caom2:cval2>
+                <caom2:cval1>1.0</caom2:cval1>
+                <caom2:cval2>4.0</caom2:cval2>
                 <caom2:type>1</caom2:type>
               </caom2:vertex>
               <caom2:vertex>

--- a/caom2utils/caom2utils/tests/test_polygonvalidator.py
+++ b/caom2utils/caom2utils/tests/test_polygonvalidator.py
@@ -91,7 +91,7 @@ def test_open_polygon():
     # should detect that the polygons is not clockwise
     with pytest.raises(AssertionError) as ex:
         validate_polygon(shape.Polygon(counter_clockwise_points))
-    assert('not in clockwise direction' in str(ex.value))
+    assert('clockwise winding direction' in str(ex.value))
     # should detect that polygon is requires a minimum of 4 points
     with pytest.raises(AssertionError) as ex:
         validate_polygon(shape.Polygon(too_few_points))
@@ -222,7 +222,7 @@ def test_open_multipolygon():
     # should detect that the polygons is not clockwise
     with pytest.raises(AssertionError) as ex:
         validate_multipolygon(shape.MultiPolygon(counter_clockwise_vertices))
-    assert('not in clockwise direction' in str(ex.value))
+    assert('clockwise winding direction' in str(ex.value))
     # should detect that there are not enough number of vertices to
     # produce a multipolygon
     with pytest.raises(AssertionError) as ex:


### PR DESCRIPTION
…d to conform to the intersection and direction rules. Commented out the statements to validate samples.

Changed the samples in SampleComposite-CAOM-2.3.xml so that the direction fails validation if we validate samples. 

Also updated validation error message to be the same as that in the java implementation.