### PR TITLE
Expanding ObservationIntentType to include outreach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.o
 *.so
 __pycache__
+.pytest_cache
+.eggs
 
 # Ignore .c files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, use `git add -f filename.c`.
@@ -16,6 +18,7 @@ htmlcov
 .coverage
 MANIFEST
 .ipynb_checkpoints
+version.py
 
 # Sphinx
 docs/api
@@ -51,6 +54,8 @@ distribute-*.tar.gz
 .project
 .pydevproject
 .settings
+.vscode
+.conda
 
 # Mac OSX
 .DS_Store

--- a/caom2/caom2/data/CAOM-2.4.xsd
+++ b/caom2/caom2/data/CAOM-2.4.xsd
@@ -735,6 +735,7 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="science"/>
             <xs:enumeration value="calibration"/>
+            <xs:enumeration value="outreach"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/caom2/caom2/observation.py
+++ b/caom2/caom2/observation.py
@@ -100,6 +100,7 @@ class ObservationIntentType(OrderedEnum):
     """
     SCIENCE = "science"
     CALIBRATION = "calibration"
+    OUTREACH = "outreach"
 
 
 class Status(Enum):

--- a/caom2/caom2/tests/test_observation.py
+++ b/caom2/caom2/tests/test_observation.py
@@ -107,6 +107,8 @@ class TestEnums(unittest.TestCase):
                          "calibration")
         self.assertEqual(observation.ObservationIntentType.SCIENCE.value,
                          "science")
+        self.assertEqual(observation.ObservationIntentType.OUTREACH.value,
+                         "outreach")
 
         self.assertEqual(observation.Status.FAIL.value, "fail")
 


### PR DESCRIPTION
STScI has been ingesting observations encapsulating images created by the Office of Public Outreach into our CAOM database. We've needed to use intent_type=science for these, but ideally we would prefer an outreach intent for them. This PR expands the enumeration in both the python and xsd file to support this option.