### PR TITLE
version_fix: refactor the caom2blueprints package into caom2blueprint…

### DIFF
--- a/caom2utils/setup.cfg
+++ b/caom2utils/setup.cfg
@@ -33,7 +33,7 @@ url = https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2
 edit_on_github = False
 github_project = opencadc/caom2tools
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-version = 1.7.5
+version = 1.7.2
 
 [options]
 install_requires =


### PR DESCRIPTION
…, blueprints, parsers and wcs_parsers packages, change ProductType dictionary, add CustomWCS setter, data_util.py accepts the use case where fully qualified directory name is ./, and support the Gemini MAROON-X use case that has no positional axes.